### PR TITLE
fixed coursework II briefing link

### DIFF
--- a/material.html
+++ b/material.html
@@ -264,7 +264,7 @@
     <td>Coursework II briefing</td>
     <td><a href="l17.pdf">PDF</a> · <a href="l17_2x2.pdf">PDF (2x2)</a> · <a href="l17_handout.pdf">PDF (Handout)</a></td>
     <td>-</td>
-    <td><a href="https://youtu.be/nIGqL5qp15w">YouTube</a></td>
+    <td><a href="https://youtu.be/tzlg6HamgNM">YouTube</a></td>
   </tr>
   <tr>
     <td>17 February 2021</td>


### PR DESCRIPTION
currently points to https://youtu.be/nIGqL5qp15w, which is private. probably should link to https://youtu.be/tzlg6HamgNM instead.