### PR TITLE
Remove references to Azure Pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CS141 Website
 
-This repository contains the HTML sources for the CS141 Sitebuilder website. All commits to the `master` branch are automatically uploaded to Sitebuilder using [`sitebuilder-util`](https://github.com/mbg/sitebuilder-util) using GitHub Actions.
+This repository contains the HTML sources for the CS141 Sitebuilder website. All commits to the `master` branch are automatically uploaded to Sitebuilder using [`sitebuilder-util`](https://github.com/mbg/sitebuilder-util) running on GitHub Actions.
 
 ## Contributing 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CS141 Website
 
-This repository contains the HTML sources for the CS141 Sitebuilder website. All commits to the `master` branch are automatically uploaded to Sitebuilder using [`sitebuilder-util`](https://github.com/mbg/sitebuilder-util) running on Azure pipelines.
+This repository contains the HTML sources for the CS141 Sitebuilder website. All commits to the `master` branch are automatically uploaded to Sitebuilder using [`sitebuilder-util`](https://github.com/mbg/sitebuilder-util) using GitHub Actions.
 
 ## Contributing 
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,9 +1,0 @@
-set -e
-
-SB_ROOT=/fac/sci/dcs/teaching/material/cs141
-
-chmod +x $SB_UTIL
-
-$SB_UTIL edit --page=$SB_ROOT --file=material.html
-$SB_UTIL edit --page=$SB_ROOT/term3 --file=term3.html
-$SB_UTIL edit --page=$SB_ROOT/online-labs --file=online-labs.html


### PR DESCRIPTION
When Azure Pipelines lovingly broke (thanks Microsoft), the deployment was switched to GitHub Actions, which is now reflected in the README